### PR TITLE
SQLite等のDBMSを使用時にopTimelinePluginのガジェットを使用すると500エラーとなる問題の修正

### DIFF
--- a/lib/database/opTimelineDb.php
+++ b/lib/database/opTimelineDb.php
@@ -18,6 +18,11 @@
 class opTimelineDb
 {
 
+  public static function isMySQL()
+  {
+    return 'mysql' === self::createPDOInstance()->getAttribute(PDO::ATTR_DRIVER_NAME);
+  }
+
   public static function findVariableOfMySQL($name)
   {
     $pdo = self::createPDOInstance();

--- a/lib/util/opTimelinePluginUtil.class.php
+++ b/lib/util/opTimelinePluginUtil.class.php
@@ -47,11 +47,17 @@ class opTimelinePluginUtil
 
   public static function getFileSizeMax()
   {
-    return min(
-            (int) opTimelineDb::findVariableOfMySQL('max_allowed_packet'),
+    $maxFileSize = min(
             self::calcConfigSizeToByte(ini_get('post_max_size')),
             self::calcConfigSizeToByte(ini_get('upload_max_filesize')),
             self::DB_MAX_FILE_SIZE);
+
+    if (opTimelineDb::isMySQL())
+    {
+      return min($maxFileSize, (int) opTimelineDb::findVariableOfMySQL('max_allowed_packet'));
+    }
+
+    return $maxFileSize;
   }
 
   const ONE_KB = 1024;


### PR DESCRIPTION
MySQLのコネクションを使用している場合のみ opTimelineDb::findVariableOfMySQL() を呼び出すように変更
