### PR TITLE
Android端末からPC向けタイムライン投稿画面を表示すると写真投稿ボタンが機能しない問題の回避

### DIFF
--- a/apps/pc_frontend/modules/timeline/templates/_timelineAll.php
+++ b/apps/pc_frontend/modules/timeline/templates/_timelineAll.php
@@ -35,8 +35,11 @@ $(function(){
     $('.timeline-postform').css('padding-bottom', '30px');
     $('#timeline-textarea').attr('rows', '3');
     $('#timeline-submit-area').css('display', 'inline');
-    if (($.browser.msie && $.browser.version > 6) || $.browser.opera ||
-      navigator.userAgent.indexOf('Android') !== -1)
+
+    var ua = navigator.userAgent;
+    var androidDefaultBrowser = -1 !== ua.indexOf('Android') && -1 !== ua.indexOf('WebKit') && -1 === ua.indexOf('Chrome');
+
+    if (($.browser.msie && $.browser.version > 6) || $.browser.opera || androidDefaultBrowser)
     {
       $('#timeline-upload-photo-button').remove();
       $('#timeline-submit-upload').css('display', 'inline');

--- a/apps/pc_frontend/modules/timeline/templates/_timelineCommunity.php
+++ b/apps/pc_frontend/modules/timeline/templates/_timelineCommunity.php
@@ -48,8 +48,11 @@ $(function(){
     $('.timeline-postform').css('padding-bottom', '30px');
     $('#timeline-textarea').attr('rows', '3');
     $('#timeline-submit-area').css('display', 'inline');
-    if ($.browser.msie && $.browser.version > 6 || $.browser.opera ||
-      navigator.userAgent.indexOf('Android') !== -1)
+
+    var ua = navigator.userAgent;
+    var androidDefaultBrowser = -1 !== ua.indexOf('Android') && -1 !== ua.indexOf('WebKit') && -1 === ua.indexOf('Chrome');
+
+    if (($.browser.msie && $.browser.version > 6) || $.browser.opera || androidDefaultBrowser)
     {
       $('#timeline-upload-photo-button').remove();
       $('#timeline-submit-upload').css('display', 'inline');


### PR DESCRIPTION
Android標準ブラウザでは、画面に表示されていない `<input type="file">` をJavaScriptから操作してファイル選択画面を表示させる方法は使用できないようになっている。
そのため、Android端末からタイムライン投稿画面を表示した場合には `<input type="file">` をユーザーに見える形にして写真の投稿ができるようにする修正を施した。
