### PR TITLE
タイムラインに表示されるメンバー画像が、メイン画像指定を考慮していない

### DIFF
--- a/lib/model/opTimelineUser.class.php
+++ b/lib/model/opTimelineUser.class.php
@@ -209,6 +209,7 @@ class opTimelineUser
     {
       $q->from('MemberImage mi, mi.File f');
       $q->select('mi.member_id, f.name');
+      $q->where('mi.is_primary = true');
 
       $searchResult = $q->fetchArray();
       $queryCacheHash = $q->calculateQueryCacheHash();


### PR DESCRIPTION
### Overview (現象)

メイン画像として設定していないメンバー画像がタイムライン上のメンバー画像として表示されてしまうことがある。
### Causes (原因)

メンバー画像を取得するSQLが member_image.is_primary を考慮していないことが原因。
### Way to fix (修正内容)

メンバー画像取得時に member_image.is_primary を考慮するように修正する。
