### PR TITLE
postformからのアクティビティ投稿時にタイムラインの更新を行う

### DIFF
--- a/web/js/timeline-loader-smartphone.js
+++ b/web/js/timeline-loader-smartphone.js
@@ -144,9 +144,9 @@ $(function(){
     lengthCheck($(this), $('button[data-timeline-id=' + $(this).attr('data-timeline-id') + ']'));
   });
 
-  // postform の送信完了を検知
-  $('.postform').on('DOMAttrModified', function(ev) {
-    if (ev.attrName === 'style' && ev.originalEvent.newValue.indexOf('display: none') !== -1) {
+  // アクティビティの投稿を検知
+  $(document).ajaxSuccess(function(event, xhr, settings) {
+    if (0 === settings.url.indexOf(openpne.apiBase + 'activity/post.json')) {
       timelineAllLoad();
     }
   });


### PR DESCRIPTION
### Overview (概要)

スマートフォン版UIのアクティビティ投稿欄 (以下 postform) からアクティビティを投稿した際に、同じページに表示されているタイムラインガジェットには反映されず手動でリロードを行う必要があり不便なため、postform のからの投稿を検知してタイムラインを更新する機能を追加する。
### Spec (仕様)

postform の DOMAttrModified イベントを監視して、投稿を検知したときにタイムラインの更新を行う。
少々強引な方法であり本来は postform 側で投稿を通知するような仕組みを用意すべきであるが、ここではプラグインのみの変更で済む方法を採った。
