### PR TITLE
スマートフォン版のコミュニティタイムライン表示で </div> が余分に入っている問題を修正

### DIFF
--- a/apps/pc_frontend/modules/timeline/templates/_smtTimelineCommunity.php
+++ b/apps/pc_frontend/modules/timeline/templates/_smtTimelineCommunity.php
@@ -44,8 +44,6 @@ var fileMaxSizeInfo = {
             <div class="timeline-post-body" id="timeline-body-context-${id}">
               {{html body_html}}
             </div>
-            </div>
-
           </div>
 
 


### PR DESCRIPTION
### Overview (現象)

スマートフォン版 UI のコミュニティタイムラインのマークアップが一部壊れているためこれを修正する。
