### PR TITLE
タイムラインの自動読み込みのタイミングで投稿を行うと投稿した内容が重複して表示されてしまう問題の修正

### DIFF
--- a/web/js/timeline-loader.api.js
+++ b/web/js/timeline-loader.api.js
@@ -234,10 +234,12 @@ function timelineDifferenceLoad() {
     if (json.data)
     {
       var lastId = $('#timeline-list').attr('data-last-id');
-      for (var i in json.data) {
-        if (json.data[i].id <= lastId)
-          delete json.data[i];
-      }
+      json.data = $.map(json.data, function(value, i) {
+        if (value.id <= lastId)
+          return null; // delete
+        else
+          return value;
+      })
       renderJSON(json, 'diff');
     }
   });


### PR DESCRIPTION
### Overview (現象)

タイムラインの自動更新が行われるタイミングと同時に投稿を行うと、投稿した内容が 2 つ表示されてしまう場合がある。
### Causes (原因)

タイムラインの自動更新時に重複チェックを行わないため、
1. タイムラインに表示されている最も新しい投稿のID (A) をチェック
2. A 以降の新しい投稿を取得する
3. 取得した投稿を表示する

の順番での 2 と 3 の間で投稿が行われると同一の投稿が 2 重に表示されてしまう。
### Way to fix (修正内容)

タイムラインの自動更新時に重複チェックを行う
