### PR TITLE
画像クリック時にオリジナルサイズの画像を表示できないバグの修正

### DIFF
--- a/lib/model/opTimeline.class.php
+++ b/lib/model/opTimeline.class.php
@@ -411,7 +411,7 @@ class opTimeline
       if (isset($imageUrls[$id]))
       {
         $data['body'] = $data['body'].' '.$imageUrls[$id];
-        $data['body_html'] = $data['body_html'].'<a href="'.$imageUrls[$id].'" rel="lightbox"><div><img src="'.$imageUrls[$id].'"></div></a>';
+        $data['body_html'] = $data['body_html'].'<a href="'.$data['image_large_url'].'" rel="lightbox"><div><img src="'.$imageUrls[$id].'"></div></a>';
       }
     }
 


### PR DESCRIPTION
画像を押下した際にオリジナルサイズの画像がlightboxでモーダルに表示される部分の修正を f082fc2b23d398c8bb088013c66035b092cd231f から分割してコミットしました。
