### PR TITLE
#4 の修正をフレンドのタイムラインガジェットに対しても適用

### DIFF
--- a/apps/pc_frontend/modules/timeline/templates/_timelineFriend.php
+++ b/apps/pc_frontend/modules/timeline/templates/_timelineFriend.php
@@ -36,7 +36,11 @@ $(function(){
     $('.timeline-postform').css('padding-bottom', '30px');
     $('#timeline-textarea').attr('rows', '3');
     $('#timeline-submit-area').css('display', 'inline');
-    if (($.browser.msie && $.browser.version > 6) || $.browser.opera)
+
+    var ua = navigator.userAgent;
+    var androidDefaultBrowser = -1 !== ua.indexOf('Android') && -1 !== ua.indexOf('WebKit') && -1 === ua.indexOf('Chrome');
+
+    if (($.browser.msie && $.browser.version > 6) || $.browser.opera || androidDefaultBrowser)
     {
       $('#timeline-upload-photo-button').remove();
       $('#timeline-submit-upload').css('display', 'inline');


### PR DESCRIPTION
Android標準ブラウザから画像投稿を行えない問題 (#4) がPC版「フレンドのタイムライン」ガジェットでも発生しているため修正しました
