### PR TITLE
README を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ opTimelinePlugin
 ## インストール方法
 * 以下のコマンドを実行して下さい。  
  プラグインをダウンロードします。  
-    ./symfony opPlugin:install opTimelinePlugin -r 1.1.6  
+    ./symfony opPlugin:install opTimelinePlugin
  スマートフォン対応する場合はパッチを適用します。  
     cd OpenPNE_dir  
     patch -p0 < plugins/opTimelinePlugin/data/patches/384.diff  


### PR DESCRIPTION
`README.md` ファイル内のインストール手順では、`opPlugin:install` タスクに `-r` オプションを指定してバージョンを明示しているためリリース毎にバージョン番号を更新する必要が出てしまう。
しかし `-r` オプションは省略しても最新の stable が自動で選択されてインストールが行われるため、このオプションは不要であると判断し削除する。