### PR TITLE
(refs #3781) 商品IDを含まない amazon のリンクの修正

### DIFF
--- a/web/js/timeline-loader.api.js
+++ b/web/js/timeline-loader.api.js
@@ -432,8 +432,12 @@ function autoLinker(json)
         if (match_id) {
           id = RegExp.$1;
         }
-        var url = 'http://amazon.openpne.jp/?id=' + id + '&tag=';
-        json.data[i].body_html = json.data[i].body.replace(/((http:|https:)\/\/www\.amazon\..*\/([a-zA-Z0-9_\-]+)\/.*)/, '<div><iframe MARGINWIDTH="0" MARGINHEIGHT="0" HSPACE="0" VSPACE="0" FRAMEBORDER="0" SCROLLING="no" BORDERCOLOR="#000000" src="' + url + '" name="sample" width="360" height="320">この部分はインラインフレームを使用しています。</iframe></div>');
+        if ('undefined' != (typeof id)){
+          var url = 'http://amazon.openpne.jp/?id=' + id + '&tag=';
+          json.data[i].body_html = json.data[i].body.replace(/((http:|https:)\/\/www\.amazon\..*\/([a-zA-Z0-9_\-]+)\/.*)/, '<div><iframe MARGINWIDTH="0" MARGINHEIGHT="0" HSPACE="0" VSPACE="0" FRAMEBORDER="0" SCROLLING="no" BORDERCOLOR="#000000" src="' + url + '" name="sample" width="360" height="320">この部分はインラインフレームを使用しています。</iframe></div>');
+        }else{
+          json.data[i].body_html = json.data[i].body.replace(/((http:|https:)\/\/[\x21-\x26\x28-\x7e]+)/gi, '<a href="$1"><div class="urlBlock"><img src="http://mozshot.nemui.org/shot?$1"><br />$1</div></a>');
+        }
       }
       else if (json.data[i].body.match(/((http:|https:)\/\/[\x21-\x26\x28-\x7e]+)/))
       {


### PR DESCRIPTION
(refs #3781) 商品IDを含まない amazon のリンクを投稿された場合は、その他のURL投稿時と同様にサイトのサムネイルを表示するように修正しました。